### PR TITLE
Fix and add badge colors on homepage hero

### DIFF
--- a/client/src/components/AdminHomepageEditor.tsx
+++ b/client/src/components/AdminHomepageEditor.tsx
@@ -266,6 +266,9 @@ export const AdminHomepageEditor: React.FC<AdminHomepageEditorProps> = ({
                           <option value="bg-gaming-accent">Blue</option>
                           <option value="bg-gaming-warning">Yellow</option>
                           <option value="bg-gaming-primary">Purple</option>
+                          <option value="bg-gaming-danger">Red</option>
+                          <option value="bg-gaming-info">Light Blue</option>
+                          <option value="bg-gaming-orange">Orange</option>
                         </select>
                         <Button
                           onClick={() => removeBadge(badge.id)}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -20,9 +20,13 @@
     --primary-foreground: 210 40% 98%;
     
     --primary-glow: 280 85% 70%;
-    --gaming-accent: 120 60% 50%;
+    --gaming-primary: 280 85% 60%;
+    --gaming-accent: 200 95% 50%;
     --gaming-warning: 45 90% 60%;
     --gaming-success: 140 65% 50%;
+    --gaming-danger: 0 85% 60%;
+    --gaming-info: 210 80% 60%;
+    --gaming-orange: 25 95% 55%;
 
     --secondary: 210 25% 18%;
     --secondary-foreground: 210 40% 98%;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -44,9 +44,13 @@ export default {
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",
+        "gaming-primary": "hsl(var(--gaming-primary))",
         "gaming-accent": "hsl(var(--gaming-accent))",
         "gaming-warning": "hsl(var(--gaming-warning))",
         "gaming-success": "hsl(var(--gaming-success))",
+        "gaming-danger": "hsl(var(--gaming-danger))",
+        "gaming-info": "hsl(var(--gaming-info))",
+        "gaming-orange": "hsl(var(--gaming-orange))",
         chart: {
           "1": "hsl(var(--chart-1))",
           "2": "hsl(var(--chart-2))",


### PR DESCRIPTION
Fixes blue and purple badge colors in the hero section and adds red, light blue, and orange color options for badges.

---
<a href="https://cursor.com/background-agent?bcId=bc-a2ca4e67-0fc9-458d-91f7-e1799989c213">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a2ca4e67-0fc9-458d-91f7-e1799989c213">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>