### PR TITLE
Add 4 specific badge colors: Forest Green, Midnight Blue, Deep Emeral…

### DIFF
--- a/client/src/components/AdminHomepageEditor.tsx
+++ b/client/src/components/AdminHomepageEditor.tsx
@@ -272,6 +272,10 @@ export const AdminHomepageEditor: React.FC<AdminHomepageEditorProps> = ({
                           <option value="bg-gaming-black">Black</option>
                           <option value="bg-gaming-dark-gray">Dark Gray</option>
                           <option value="bg-gaming-charcoal">Charcoal</option>
+                          <option value="bg-gaming-forest-green">Forest Green</option>
+                          <option value="bg-gaming-midnight-blue">Midnight Blue</option>
+                          <option value="bg-gaming-deep-emerald">Deep Emerald</option>
+                          <option value="bg-gaming-prussian-blue">Prussian Blue</option>
                         </select>
                         <Button
                           onClick={() => removeBadge(badge.id)}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -30,6 +30,10 @@
     --gaming-black: 0 0% 0%;
     --gaming-dark-gray: 0 0% 7%;
     --gaming-charcoal: 0 0% 10%;
+    --gaming-forest-green: 120 67% 13%;
+    --gaming-midnight-blue: 240 60% 27%;
+    --gaming-deep-emerald: 140 97% 13%;
+    --gaming-prussian-blue: 200 100% 16%;
 
     --secondary: 210 25% 18%;
     --secondary-foreground: 210 40% 98%;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -54,6 +54,10 @@ export default {
         "gaming-black": "hsl(var(--gaming-black))",
         "gaming-dark-gray": "hsl(var(--gaming-dark-gray))",
         "gaming-charcoal": "hsl(var(--gaming-charcoal))",
+        "gaming-forest-green": "hsl(var(--gaming-forest-green))",
+        "gaming-midnight-blue": "hsl(var(--gaming-midnight-blue))",
+        "gaming-deep-emerald": "hsl(var(--gaming-deep-emerald))",
+        "gaming-prussian-blue": "hsl(var(--gaming-prussian-blue))",
         chart: {
           "1": "hsl(var(--chart-1))",
           "2": "hsl(var(--chart-2))",


### PR DESCRIPTION
…d, Prussian Blue

- Added Forest Green (#0b3d0b) as --gaming-forest-green
- Added Midnight Blue (#191970) as --gaming-midnight-blue
- Added Deep Emerald (#014421) as --gaming-deep-emerald
- Added Prussian Blue (#003153) as --gaming-prussian-blue
- Updated Tailwind config with new color definitions
- Added new color options to AdminHomepageEditor dropdown
- All colors properly converted to HSL format for consistency