### PR TITLE
Update policy names and enable admin editing

### DIFF
--- a/client/src/pages/Index.tsx
+++ b/client/src/pages/Index.tsx
@@ -977,7 +977,7 @@ const Index = () => {
           <div className="text-center mb-12">
             <h2 className="text-3xl font-bold mb-4 text-primary">{homepageContent.features.title}</h2>
             <p className="text-muted-foreground">
-              {homepageContent.features.subtitle} Read our{' '}
+              {homepageContent.features.subtitle}{' '}
               <a 
                 href="/purchase-policy" 
                 className="text-primary hover:text-primary/80 underline transition-colors"


### PR DESCRIPTION
Remove "Read our" prefix from policy link text.

This change fulfills the user's request to modify the display text from "Read our Purchase Policy and Terms of Service" to "Purchase Policy and Terms of Service". The request also included allowing admins to edit policy pages, which was confirmed to be an existing and fully functional feature.

---
<a href="https://cursor.com/background-agent?bcId=bc-c47ee003-ab0f-4576-b2f9-0e21942e12d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c47ee003-ab0f-4576-b2f9-0e21942e12d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

