### PR TITLE
Fix support ticket creation and add to section

### DIFF
--- a/client/src/components/SupportButton.tsx
+++ b/client/src/components/SupportButton.tsx
@@ -7,7 +7,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { HelpCircle, MessageSquare, Ticket, Send } from "lucide-react";
-import { supabase } from "@/lib/supabase";
+import { simpleSupabase } from "@/lib/simple-supabase";
 import { useToast } from "@/hooks/use-toast";
 import { useLocation } from "wouter";
 
@@ -48,18 +48,16 @@ export const SupportButton = ({ user }: SupportButtonProps) => {
     setIsSubmitting(true);
 
     try {
-      const { data, error } = await supabase
+      // Use the working client and correct field names
+      const { data, error } = await simpleSupabase
         .from('support_tickets')
         .insert({
           user_id: user.id,
           subject: subject.trim(),
           category: category,
-          description: description.trim(),
+          message: description.trim(), // Use 'message' to match Ticket interface
           status: 'open',
-          priority: 'medium'
-        })
-        .select()
-        .single();
+        });
 
       if (error) throw error;
 


### PR DESCRIPTION
Fix support ticket creation and ensure tickets appear in the support section.

Ticket creation failed because the `SupportButton` used the incorrect Supabase client and inserted the ticket content into a `description` field instead of the expected `message` field, preventing tickets from being displayed correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-5feb60b9-44db-4aab-9bcd-bda162ce4455">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5feb60b9-44db-4aab-9bcd-bda162ce4455">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

